### PR TITLE
FEAT: add spence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 /src/spexial/_version.py
 .mypy_cache
+.hypothesis
+.coverage

--- a/src/spexial/__init__.py
+++ b/src/spexial/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "K1",
     "K2",
     "Li", # NOTE: not in scipy.special
+    "spence",
     "zeta"
 ]
 
@@ -19,5 +20,6 @@ from ._src.comb import comb
 from ._src.gamma import gamma
 from ._src.kn import K0,K1,K2
 from ._src.polylog import Li
+from ._src.spence import spence
 from ._src.zeta import Riemann_zeta as zeta
 

--- a/src/spexial/_src/spence.py
+++ b/src/spexial/_src/spence.py
@@ -29,7 +29,7 @@ def complex_spence_series_0(z):
     sum2 = jnp.sum(temp)
     
     return jnp.where(
-        abs(z) < 1e-15,
+        z == 0,
         np.pi**2 / 6,
         np.pi**2 / 6 - sum1 + jnp.log(z) * sum2
     )
@@ -117,7 +117,6 @@ def spence_jvp(primals, tangents):
     (z,) = primals
     (z_dot,) = tangents
     dspence = spence_gradient(z)
-    jax.debug.print("{} {}", dspence, z_dot)
     return spence(z), z_dot * dspence
 
 

--- a/src/spexial/_src/spence.py
+++ b/src/spexial/_src/spence.py
@@ -13,11 +13,14 @@ import numpy as np
 MAXITER = 500
 
 
-@jax.numpy.vectorize
+@jnp.vectorize
 def complex_spence_series_0(z):
-    """
+    r"""
     Small z branch, uses a series expansion about :math:`z = 0`
     for :math:`|z| < 0.5`.
+
+    The third term diverges for :math:`|z| \rightarrow 0` so we special case
+    it.
     """
     
     nn = jnp.arange(1, MAXITER)
@@ -25,10 +28,14 @@ def complex_spence_series_0(z):
     sum1 = jnp.sum(temp / nn)
     sum2 = jnp.sum(temp)
     
-    return np.pi**2 / 6 - sum1 + jnp.log(z) * sum2
+    return jnp.where(
+        abs(z) < 1e-15,
+        np.pi**2 / 6,
+        np.pi**2 / 6 - sum1 + jnp.log(z) * sum2
+    )
 
 
-@jax.numpy.vectorize
+@jnp.vectorize
 def complex_spence_series_1(z):
     """
     Middle branch, an expansion around :math:`z = 1`
@@ -48,19 +55,33 @@ def complex_spence_series_2(z):
     """
     Large :math:`z` branch for :math:`|z| > 0.5` and
     :math:`|1 - z| > 1`. Uses a reflection expression.
+
+    This gives a :code:`ZeroDivisionError` for `z = 1`. Since every branch is
+    evaluated when this has been :code:`vmap`-ed, we perturb the value
+    slightly.
     """
+    val = jnp.where(z == 1, z, z + 1e-10)
     return (
-        -complex_spence_series_1(z / (z - 1))
+        -complex_spence_series_1(val / (val - 1))
         - np.pi**2 / 6
-        - jnp.log(z - 1)**2 / 2
+        - jnp.log(val - 1)**2 / 2
     )
 
 
 @jax.jit
 def spence(z):
-    """
+    r"""
     Return the Spence dilogarithm for complex input using
     branches dependent on the value of the input.
+
+    .. math::
+
+        \int_{1}^{z} dt \frac{\log(t)}{1 - t}
+
+    See Also
+    --------
+    scipy.special.spence: the reference implementation in scipy
+    jax.scipy.special.spence: jax implementation for real inputs
     """
     return jax.lax.select(
         abs(z) < 0.5,
@@ -73,11 +94,30 @@ def spence(z):
     )
 
 
+def spence_gradient(z):
+    r"""
+    Analytic gradient of the spence dilogarithm. Since :code:`spence` is
+    defined via an integral, this is just the integrand
+
+    .. math::
+
+        \frac{\log(z)}{1 - z}
+
+    We call out special cases where one of the two terms will diverge.
+    """
+    return jnp.where(
+        (z == 0) | (z == 1),
+        0.0,
+        jnp.log(z) / (1 - z),
+    )
+
+
 def spence_jvp(primals, tangents):
     """Template of spence jvp that different implementations can use"""
     (z,) = primals
     (z_dot,) = tangents
-    dspence = jnp.log(z) / (1 - z)
+    dspence = spence_gradient(z)
+    jax.debug.print("{} {}", dspence, z_dot)
     return spence(z), z_dot * dspence
 
 

--- a/src/spexial/_src/spence.py
+++ b/src/spexial/_src/spence.py
@@ -1,0 +1,83 @@
+"""
+Translation of the cython implementation of complex Spence
+from scipy to work with jax.
+
+Adapted from https://github.com/scipy/scipy/blob/8971d5e9b72931987b7d3c5a25da1a8e7e5485d0/scipy/special/_spence.pxd
+"""
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+MAXITER = 500
+
+
+def complex_spence_series_0(z):
+    """
+    Small z branch, uses a series expansion about :math:`z = 0`
+    for :math:`|z| < 0.5`.
+    """
+    
+    nn = jnp.arange(1, MAXITER)
+    temp = z**nn / nn
+    sum1 = jnp.sum(temp / nn)
+    sum2 = jnp.sum(temp)
+    
+    return np.pi**2 / 6 - sum1 + jnp.log(z) * sum2
+
+
+def complex_spence_series_1(z):
+    """
+    Middle branch, an expansion around :math:`z = 1`
+    for :math:`|z| > 0.5` and :math:`|1 - z| > 1`.
+    """
+    z = 1 - z
+    nn = jnp.arange(1, MAXITER)
+    res = jnp.sum(z**nn / (nn * (nn + 1) * (nn + 2))**2)
+
+    res *= 4 * z**2
+    res += 4 * z + 5.75 * z**2 + 3 * (1 - z**2) * jnp.log1p(-z)
+    res /= 1 + 4 * z + z**2
+    return res
+
+
+def complex_spence_series_2(z):
+    """
+    Large :math:`z` branch for :math:`|z| > 0.5` and
+    :math:`|1 - z| > 1`. Uses a reflection expression.
+    """
+    return (
+        -complex_spence_series_1(z / (z - 1))
+        - np.pi**2 / 6
+        - jnp.log(z - 1)**2 / 2
+    )
+
+
+@jax.jit
+def spence(z):
+    """
+    Return the Spence dilogarithm for complex input using
+    branches dependent on the value of the input.
+    """
+    return jax.lax.select(
+        abs(z) < 0.5,
+        complex_spence_series_0(z),
+        jax.lax.select(
+            abs(1 - z) > 1,
+            complex_spence_series_2(z),
+            complex_spence_series_1(z),
+        ),
+    )
+
+
+def spence_jvp(primals, tangents):
+    """Template of spence jvp that different implementations can use"""
+    (z,) = primals
+    (z_dot,) = tangents
+    dspence = jnp.log(z) / (1 - z)
+    return spence(z), z_dot * dspence
+
+
+spence = jax.custom_jvp(spence)
+spence.defjvp(spence_jvp)

--- a/src/spexial/_src/spence.py
+++ b/src/spexial/_src/spence.py
@@ -13,6 +13,7 @@ import numpy as np
 MAXITER = 500
 
 
+@jax.numpy.vectorize
 def complex_spence_series_0(z):
     """
     Small z branch, uses a series expansion about :math:`z = 0`
@@ -27,6 +28,7 @@ def complex_spence_series_0(z):
     return np.pi**2 / 6 - sum1 + jnp.log(z) * sum2
 
 
+@jax.numpy.vectorize
 def complex_spence_series_1(z):
     """
     Middle branch, an expansion around :math:`z = 1`

--- a/tests/regression/test_spence.py
+++ b/tests/regression/test_spence.py
@@ -1,0 +1,47 @@
+"""Test `spexial.spence` matches `scipy.special`."""
+
+import jax
+import numpy as np
+from hypothesis import example, given, settings, strategies as st
+from scipy.special import spence as scipy_spence
+
+from spexial import spence
+
+
+@given(st.floats(min_value=0, max_value=10), st.floats(min_value=0, max_value=2 * np.pi))
+@example(1.0, 0.0)
+@example(5, 0)
+@settings(deadline=1000)  # Set the maximum time for this test to 1000ms
+def test_eval_spence(x, phi):
+    r"""
+    Test `spexial.spence` matches `scipy.special`.
+
+    There is a branch point on the negative real axis and so tests at, e.g.,
+    :math:`-1 + \epsilon` and :math:`-1 - \epsilon` give very different results
+    so I took this somewhat roundabout method to get complex numbers.
+    """
+    z = x * np.exp(1j * phi)
+    result = spence(z)
+    expected = scipy_spence(z)
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
+    result = spence(x)
+    expected = scipy_spence(x)
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
+
+
+@given(st.floats(min_value=0.1, max_value=10))
+@example(0.0)
+@settings(deadline=1000)  # Set the maximum time for this test to 1000ms
+def test_grad_spence_real(x):
+    r"""
+    Test the gradient of `spexial.spence` matches `jax.scipy.special`.
+
+    For some reason, the gradient of the jax implementation returns nan
+    between one and two and has numerical issues for small x.
+    """
+    if abs(x - 1.5) < 0.5:
+        x += 1
+    print(x)
+    result = jax.grad(spence)(x)
+    expected = jax.grad(jax.scipy.special.spence)(x)
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
This is an implementation I have of `scipy.special.spence` for complex input. `jax.scipy.special` implements the function for real inputs.

This has significant over lap with `polylog/Li` but matches the scipy API more closely (scipy uses a slightly unusual definition). The current implementation `Li` gives the generic polylogarithm while this should match

```python
spence(z) = Li(2, 1 - z)
```

There are also some differences for complex inputs and I think this implementation matches `scipy` better, for example

```python
In [10]: spence(2 - 0.1j)
Out[10]: np.complex128(-0.8234321080805467+0.06929202401162238j)

In [11]: spexial.spence(2 - 0.1j)
Out[11]: Array(-0.8234399+0.06928854j, dtype=complex64)

In [12]: spexial.Li(2, 1 - (2 - 0.1j))
Out[12]: Array(nan+0.j, dtype=complex64)
```